### PR TITLE
Changing Version to be 6.0 instead of 5.0

### DIFF
--- a/CEP_6.x/ExtensionManifest_v_6_0.xsd
+++ b/CEP_6.x/ExtensionManifest_v_6_0.xsd
@@ -501,7 +501,7 @@
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
-                        <xs:enumeration value="5.0"/>
+                        <xs:enumeration value="6.0"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>


### PR DESCRIPTION
ExtensionManifest_v_6_0.xsd still had 5.0 as the version enumeration.
