### PR TITLE
Updated product table for the invisible extensions

### DIFF
--- a/CEP_9.x/Documentation/CEP 9.0 HTML Extension Cookbook.md
+++ b/CEP_9.x/Documentation/CEP 9.0 HTML Extension Cookbook.md
@@ -2273,7 +2273,7 @@ One important thing to note is that not all host applications support Invisible 
 |After Effects	|Yes	 |
 |Animate (Flash Pro)|	Yes	 |
 |Audition|	Yes|	 
-|InDesign|	Yes|	|
+|InDesign|	Yes|	However, as of 2019 you must include a width and height.|
 |InCopy|	No|	Doesn't work at all because InCopy doesn't support 'Custom' window type.|
 |Illustrator|	Yes|	|
 

--- a/CEP_9.x/Documentation/CEP 9.0 HTML Extension Cookbook.md
+++ b/CEP_9.x/Documentation/CEP 9.0 HTML Extension Cookbook.md
@@ -2274,7 +2274,7 @@ One important thing to note is that not all host applications support Invisible 
 |Animate (Flash Pro)|	Yes	 |
 |Audition|	Yes|	 
 |InDesign|	Yes|	However, as of 2019 you must include a width and height.|
-|InCopy|	No|	Doesn't work at all because InCopy doesn't support 'Custom' window type.|
+|InCopy|	Yes|	However, as of 2019 you must include a width and height.|
 |Illustrator|	Yes|	|
 
 

--- a/CEP_9.x/Documentation/CEP 9.0 HTML Extension Cookbook.md
+++ b/CEP_9.x/Documentation/CEP 9.0 HTML Extension Cookbook.md
@@ -2270,9 +2270,10 @@ One important thing to note is that not all host applications support Invisible 
 |Photoshop|	Yes|	 
 |Premiere Pro|	Yes|	 
 |Prelude	|Yes	 |
+|After Effects	|Yes	 |
 |Animate (Flash Pro)|	Yes	 |
 |Audition|	Yes|	 
-|InDesign|	No|	Doesn't work at all because InDesign doesn't support 'Custom' window type.|
+|InDesign|	Yes|	|
 |InCopy|	No|	Doesn't work at all because InCopy doesn't support 'Custom' window type.|
 |Illustrator|	Yes|	|
 


### PR DESCRIPTION
The table in this section on invisible extensions is out of date. InDesign does support invisible extensions (Harbs can confirm 2017 does). After Effects isn't listed at all, but AE does support invisible extensions.