### PR TITLE
Wrong variable name in onError function

### DIFF
--- a/ExtendScript-Toolkit/Samples/javascript/MessagingBetweenApps.jsx
+++ b/ExtendScript-Toolkit/Samples/javascript/MessagingBetweenApps.jsx
@@ -110,7 +110,7 @@ MessagingBetweenApps.prototype.run = function() {
 	// ESTK handles any errors  that occur when sending the initial message
 	btMsg.onError = function( errorMsg ) {
 		 retval = false; 
-		 $.writeln(eObj.body); 
+		 $.writeln(errorMsg.body); 
 	}
 	// ESTK sends the initial message
 	$.writeln("MessagingBetweenApps: In ESTK - about to send initial message to Photoshop");


### PR DESCRIPTION
When the onError method of the btMsg object should log the body message, the function parameter is errorMsg, but the argument passed to the writeln function is eObj. The console will not log the error, because you are trying to access a property of a nonexistent object.