### PR TITLE
Updated the Documentation for CEP_8.X

### DIFF
--- a/CEP_8.x/Documentation/CEP 8.0 HTML Extension Cookbook.md
+++ b/CEP_8.x/Documentation/CEP 8.0 HTML Extension Cookbook.md
@@ -992,7 +992,7 @@ Here is the definition for `CSInterface.dispatchEvent`. Refer to `CSInterface.js
 
 ```js
 /**
- * Triggers a CEP event programmatically. Yoy can use it to dispatch
+ * Triggers a CEP event programmatically. You can use it to dispatch
  * an event of a predefined type, or of a type you have defined.
  *
  * @param event A \c CSEvent object.
@@ -1010,7 +1010,7 @@ Here are three samples to demonstrate how to dispatch an event in JavaScript.
 var csInterface = new CSInterface();
 var event = new CSEvent("com.adobe.cep.test", "APPLICATION");
 event.data = "This is a test!";
-cSInterface.dispatchEvent(event);
+csInterface.dispatchEvent(event);
 ```	
 
 
@@ -1023,7 +1023,7 @@ var event = new CSEvent();
 event.type = "com.adobe.cep.test";
 event.scope = "APPLICATION";
 event.data = "This is a test!";
-cSInterface.dispatchEvent(event);
+csInterface.dispatchEvent(event);
 ```
 
 
@@ -1036,7 +1036,7 @@ var obj = new Object();
 obj.a = "a";
 obj.b = "b";
 event.data = obj;
-cSInterface.dispatchEvent(event);
+csInterface.dispatchEvent(event);
 ```
 
 


### PR DESCRIPTION
Fixed 2 minor typos. The first one was changing a **Yoy** to **You** and the other was changing the case for **csInterface** from **cSInterface** in the code.